### PR TITLE
Fix Clippy warnings in TDX attestation library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -96,9 +96,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -154,9 +154,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys",
@@ -288,9 +288,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -51,7 +51,7 @@ fn handle_not_supported(e: Error) -> Result<()> {
             println!("This platform does not support TDX 1.5!");
             Ok(())
         }
-        _ => return Err(e),
+        _ => Err(e),
     }
 }
 
@@ -87,14 +87,13 @@ fn main() -> Result<()> {
     let args = Cli::parse();
 
     // Handle commands
-    let result = match args.command {
+
+    match args.command {
         Commands::Platform { command } => platform::handle(command),
         Commands::Quote {
             mrtd_only,
             out_file,
             save,
         } => handle_quote(mrtd_only, out_file, save),
-    };
-
-    result
+    }
 }

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -50,7 +50,7 @@ impl GcpTdxHost {
     /// Creates a new `GcpTdxHost` instance with the given guest MRTD.
     pub fn new(mrtd_bytes: &[u8; TDX_MR_REG_LEN]) -> GcpTdxHost {
         GcpTdxHost {
-            mrtd: mrtd_bytes.clone(),
+            mrtd: *mrtd_bytes,
         }
     }
 
@@ -69,7 +69,7 @@ impl GcpTdxHost {
             .arg("cat")
             .arg(storage_url)
             .output()
-            .map_err(|e| Error::IoError(e))?;
+            .map_err(Error::IoError)?;
 
         if !output.status.success() {
             return Err(Error::VerificationError(format!(
@@ -115,7 +115,7 @@ impl TeeHost for GcpTdxHost {
     /// This method performs the following steps:
     /// 1. Retrieves the TDX guest's launch endorsement from GCP storage.
     /// 2. Verifies the signing certificate of the endorsement against Google's
-    /// root cert.
+    ///    root cert.
     /// 3. Verifies the signature on the endorsement.
     /// 4. Compares the endorsed MRTD with the guest's MRTD.
     ///
@@ -123,9 +123,9 @@ impl TeeHost for GcpTdxHost {
     ///
     /// - `Error::IoError` if the endorsement cannot be retrieved.
     /// - `Error::ParseError` if the endorsement or golden measurement cannot be
-    /// parsed.
+    ///   parsed.
     /// - `Error::SignatureError` if the certificate or signature verification
-    /// fails.
+    ///   fails.
     ///
     /// # Note
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,14 @@
 //! The library provides the following functionality:
 //! - `error`: Custom error types
 //! - `gcp`: Google Cloud Platform (GCP) host interface for TDX guests (when
-//! compiled with the `host-gcp-tdx` feature)
+//!   compiled with the `host-gcp-tdx` feature)
 //! - `host`: Host interface for VM-based trusted execution environment (TEE)
-//! guests (when compiled with the `host-verification` feature)
+//!   guests (when compiled with the `host-verification` feature)
 //! - `provider`: Trusted execution environment (TEE) attestation interface
 //! - `tdx`: Intel TDX guest attestation interface (when compiled with the
-//! `tdx-linux` feature)
+//!   `tdx-linux` feature)
 //! - `verification`: Workload attestation verification utilities (when compiled
-//! with the `host-verification` feature)
+//!   with the `host-verification` feature)
 //!
 //! ## Example Usage
 //!
@@ -36,9 +36,9 @@
 //!         // Get the launch measurement
 //!         let measurement = provider.get_launch_measurement().expect("Failed to get launch measurement");
 //!
-//!        // Do something else
+//!         // Do something else
 //!     },
-//!     _ => Err(Error::NotSupported("This platform is not supported".to_string())),  
+//!     _ => Err(Error::NotSupported("This platform is not supported".to_string())),
 //! }
 //! ```
 
@@ -70,7 +70,7 @@ use tdx::linux::is_v15_kvm_device;
 /// # Errors
 ///
 /// Returns an error if support for TDX 1.5 on Linux cannot be determined
-/// (requires the `tdx-linux1 feature).
+/// (requires the `tdx-linux` feature).
 pub fn get_platform_name() -> Result<String> {
     let name = std::env::consts::OS;
 

--- a/src/tdx/mod.rs
+++ b/src/tdx/mod.rs
@@ -33,16 +33,22 @@ pub mod report;
 use report::TdReportV15;
 
 /// The length of the `report_data` field in the TDX report.
-pub const TDX_REPORT_DATA_LEN: usize = 64 as usize;
+pub const TDX_REPORT_DATA_LEN: usize = 64_usize;
 
 /// The length of the TDX measurement registers.
-pub const TDX_MR_REG_LEN: usize = 48 as usize;
+pub const TDX_MR_REG_LEN: usize = 48_usize;
 
 /// An interface for retrieving attestation reports and launchmeasurements with
 /// TDX on Linux VM guests.
 ///
 /// This struct implements the `AttestationProvider` trait.
 pub struct LinuxTdxProvider;
+
+impl Default for LinuxTdxProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl LinuxTdxProvider {
     /// Creates a new instance of `LinuxTdxProvider`.

--- a/src/verification/signature.rs
+++ b/src/verification/signature.rs
@@ -37,7 +37,7 @@ use openssl::sign::Verifier;
 /// # Errors
 ///
 /// - `Error::SignatureError` if there are issues with the inputs, verifier
-/// setup, or configuration.
+///   setup, or configuration.
 /// - `Error::VerificationError` if the signature verification fails.
 ///
 /// # Notes
@@ -105,9 +105,9 @@ mod tests {
         let rsa = Rsa::generate(4096).unwrap();
         let pkey = PKey::from_rsa(rsa).unwrap();
         let privkey_der = &pkey.private_key_to_der().unwrap();
-        let privkey = &PKey::private_key_from_der(&privkey_der).unwrap();
+        let privkey = &PKey::private_key_from_der(privkey_der).unwrap();
         let pubkey_der = &pkey.public_key_to_der().unwrap();
-        let pubkey = &PKey::public_key_from_der(&pubkey_der).unwrap();
+        let pubkey = &PKey::public_key_from_der(pubkey_der).unwrap();
 
         TestKeys {
             privkey: privkey.clone(),

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -57,7 +57,7 @@ pub fn get_x509_pubkey(cert: &X509) -> Result<PKey<Public>> {
 ///
 /// Returns an `Error::ParseError` if the certificate cannot be parsed.
 pub fn x509_from_der_bytes(der_bytes: &[u8]) -> Result<X509> {
-    X509::from_der(&der_bytes).map_err(|e| Error::ParseError(e.to_string()))
+    X509::from_der(der_bytes).map_err(|e| Error::ParseError(e.to_string()))
 }
 
 /// Loads an X.509 certificate from a file in DER format.
@@ -94,7 +94,7 @@ pub fn load_x509_der(cert_path: &str) -> Result<X509> {
 /// This function performs two checks to verify the validity of the certificate:
 /// 1. It checks whether the provided `issuer_cert` is the issuer of the `cert`.
 /// 2. It verifies the signature of the `cert` using the public key from the
-/// `issuer_cert`.
+///    `issuer_cert`.
 ///
 /// # Errors
 ///
@@ -102,7 +102,7 @@ pub fn load_x509_der(cert_path: &str) -> Result<X509> {
 /// - `Error::SignatureError` if the signature verification fails.
 pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
     // First, check the issuer
-    match issuer_cert.issued(&cert) {
+    match issuer_cert.issued(cert) {
         X509VerifyResult::OK => {} // valid issuer so pass through
         _ => {
             return Err(Error::VerificationError(
@@ -112,7 +112,7 @@ pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
     };
 
     // Then, check the signature
-    let issuer_pkey = get_x509_pubkey(&issuer_cert)?;
+    let issuer_pkey = get_x509_pubkey(issuer_cert)?;
 
     cert.verify(&issuer_pkey)
         .map_err(|e| Error::VerificationError(e.to_string()))
@@ -162,18 +162,18 @@ mod tests {
         let rsa = Rsa::generate(4096).unwrap();
         let pkey = PKey::from_rsa(rsa).unwrap();
         let privkey_der = &pkey.private_key_to_der().unwrap();
-        let privkey = &PKey::private_key_from_der(&privkey_der).unwrap();
+        let privkey = &PKey::private_key_from_der(privkey_der).unwrap();
         let pubkey_der = &pkey.public_key_to_der().unwrap();
-        let pubkey = &PKey::public_key_from_der(&pubkey_der).unwrap();
+        let pubkey = &PKey::public_key_from_der(pubkey_der).unwrap();
 
         let rsa2 = Rsa::generate(4096).unwrap();
         let pkey2 = PKey::from_rsa(rsa2).unwrap();
         let pubkey_der2 = &pkey2.public_key_to_der().unwrap();
-        let pubkey2 = &PKey::public_key_from_der(&pubkey_der2).unwrap();
+        let pubkey2 = &PKey::public_key_from_der(pubkey_der2).unwrap();
 
         TestCerts {
-            root: make_cert(&pubkey, &privkey),
-            interm: make_cert(&pubkey2, &privkey),
+            root: make_cert(pubkey, privkey),
+            interm: make_cert(pubkey2, privkey),
         }
     }
 


### PR DESCRIPTION
This PR addresses Clippy warnings to improve code quality and documentation formatting.

