### PR TITLE
Fix doc tests

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,8 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use crate::error::{Error, Result};
+//! ```
+//! use tdx_workload_attestation::error::{Error, Result};
 //!
 //! fn example_function() -> Result<()> {
 //!     Err(Error::NotSupported("This operation is not supported".to_string()))

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -10,8 +10,8 @@
 //! ## Example Usage
 //!
 //! ```rust
-//! use gcp::GcpTdxHost;
-//! use host::TeeHost;
+//! use tdx_workload_attestation::gcp::GcpTdxHost;
+//! use tdx_workload_attestation::host::TeeHost;
 //!
 //! // Example host interface setup with dummy TDX MRTD value
 //! let mrtd = [0u8; 48];
@@ -49,9 +49,7 @@ pub struct GcpTdxHost {
 impl GcpTdxHost {
     /// Creates a new `GcpTdxHost` instance with the given guest MRTD.
     pub fn new(mrtd_bytes: &[u8; TDX_MR_REG_LEN]) -> GcpTdxHost {
-        GcpTdxHost {
-            mrtd: *mrtd_bytes,
-        }
+        GcpTdxHost { mrtd: *mrtd_bytes }
     }
 
     fn retrieve_launch_endorsement(&self) -> Result<endorsement::VMLaunchEndorsement> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,28 +17,29 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use error::Error;
-//! use tdx::LinuxTdxProvider;
-//! use tdx::AttestationProvider;
+//! ```no_run
+//! use tdx_workload_attestation::tdx::LinuxTdxProvider;
+//! use tdx_workload_attestation::provider::AttestationProvider;
+//! use tdx_workload_attestation::get_platform_name;
 //!
 //! // Get the platform name
-//! let platform = get_platform_name();
+//! let platform = get_platform_name().unwrap();
 //!
 //! // Create a new provider instance
-//! match get_platform_name() {
+//! match platform.as_str() {
 //!     "tdx-linux" => {
-//!         provider = LinuxTdxProvider::new();
+//!         let provider = LinuxTdxProvider::new();
 //!
 //!         // Get the attestation report
-//!         let report = provider.get_attestation_report().expect("Failed to get attestation report");
+//!         let report = provider.get_attestation_report().unwrap();
 //!
 //!         // Get the launch measurement
-//!         let measurement = provider.get_launch_measurement().expect("Failed to get launch measurement");
+//!         let measurement = provider.get_launch_measurement().unwrap();
 //!
 //!         // Do something else
 //!     },
-//!     _ => Err(Error::NotSupported("This platform is not supported".to_string())),
+//!     // Can also throw an error here
+//!     _ => println!("This platform does not support TDX"),
 //! }
 //! ```
 

--- a/src/tdx/linux/device.rs
+++ b/src/tdx/linux/device.rs
@@ -11,8 +11,8 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use device::TdxDeviceKvm15;
+//! ```
+//! use tdx_workload_attestation::tdx::linux::device::TdxDeviceKvmV15;
 //!
 //! // Create a new instance of TdxDeviceKvmV15
 //! let tdx_device = TdxDeviceKvmV15::new();

--- a/src/tdx/linux/mod.rs
+++ b/src/tdx/linux/mod.rs
@@ -5,8 +5,9 @@
 //! and parse the attestation report (`TDREPORT`) from the device.
 //!
 //! ## Example Usage
-//! ```rust
-//! use linux::{is_v15_kvm_device, get_tdreport_v15_kvm};
+//! ```no_run
+//! use tdx_workload_attestation::tdx::linux::{is_v15_kvm_device, get_tdreport_v15_kvm};
+//! use tdx_workload_attestation::tdx::TDX_REPORT_DATA_LEN;
 //!
 //! // Check if TDX 1.5 KVM device is available
 //! match is_v15_kvm_device() {
@@ -19,7 +20,7 @@
 //! let report_data: [u8; TDX_REPORT_DATA_LEN] = [0; TDX_REPORT_DATA_LEN];
 //!
 //! // Retrieve the TDREPORT
-//! let td_report = get_tdreport_v15_kvm(&report_data);
+//! let td_report = get_tdreport_v15_kvm(&report_data).unwrap();
 //!
 //! // Access fields from the parsed TDREPORT
 //! println!("MRTD: {:?}", td_report.get_mrtd());
@@ -33,7 +34,7 @@
 //! - The `is_v15_kvm_device` function may return an error if the device node is not accessible or valid.
 //! - The `get_tdreport_v15_kvm` function will panic if the device interaction fails (e.g., due to an invalid ioctl operation).
 
-mod device;
+pub mod device;
 
 use crate::error::Result;
 use crate::tdx::TDX_REPORT_DATA_LEN;

--- a/src/tdx/mod.rs
+++ b/src/tdx/mod.rs
@@ -9,9 +9,9 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use tdx::LinuxTdxProvider;
-//! use tdx::AttestationProvider;
+//! ```no_run
+//! use tdx_workload_attestation::tdx::LinuxTdxProvider;
+//! use tdx_workload_attestation::provider::AttestationProvider;
 //!
 //! let provider = LinuxTdxProvider::new();
 //!
@@ -83,9 +83,9 @@ impl AttestationProvider for LinuxTdxProvider {
     ///
     /// # Example
     ///
-    /// ```rust
-    /// use tdx::LinuxTdxProvider;
-    /// use tdx::AttestationProvider;
+    /// ```no_run
+    /// use tdx_workload_attestation::tdx::LinuxTdxProvider;
+    /// use tdx_workload_attestation::provider::AttestationProvider;
     ///
     /// let provider = LinuxTdxProvider::new();
     /// let report = provider.get_attestation_report().expect("Failed to get attestation report");
@@ -112,9 +112,9 @@ impl AttestationProvider for LinuxTdxProvider {
     ///
     /// # Example
     ///
-    /// ```rust
-    /// use tdx::LinuxTdxProvider;
-    /// use tdx::AttestationProvider;
+    /// ```no_run
+    /// use tdx_workload_attestation::tdx::LinuxTdxProvider;
+    /// use tdx_workload_attestation::provider::AttestationProvider;
     ///
     /// let provider = LinuxTdxProvider::new();
     /// let measurement = provider.get_launch_measurement().expect("Failed to get launch measurement");

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -6,18 +6,21 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use verification::x509::{load_x509_der, get_x509_pubkey};
-//! use verification::signature::verify_signature_sha256_rsa_pss;
+//! ```compile_fail
+//! use tdx_workload_attestation::verification::x509::{load_x509_der, get_x509_pubkey};
+//! use tdx_workload_attestation::verification::signature::verify_signature_sha256_rsa_pss;
 //!
 //! // Load signing cert
 //! let cert = load_x509_der("/path/to/cert.der")?;
 //! let signing_key = verification::x509::get_x509_pubkey(&cert)?;
 //!
-//! // Verify the digital `signature` on `data` with the `public_key` found in the cert
-//! match verify_signature_sha256_rsa_pss(data, &signature, &public_key) {
+//! // Get data and signature
+//!
+//! // Verify the digital `signature` on `data` with the `signing_key` found in the cert
+//! match verify_signature_sha256_rsa_pss(&data, &signature, &signing_key) {
 //!     Ok(true) => println!("Signature is valid."),
-//!     Err(e) => eprintln!("Signature verification failed: {}", e),
+//!     Ok(false) => println!("Signature is not valid."),
+//!     Err(e) => println!("Signature verification failed: {e}"),
 //! }
 //! ```
 

--- a/src/verification/signature.rs
+++ b/src/verification/signature.rs
@@ -7,18 +7,21 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use signature::verify_signature_sha256_rsa_pss;
-//! use x509::{load_x509_der, get_x509_pubkey};
+//! ```compile_fail
+//! use tdx_workload_attestation::verification::signature::verify_signature_sha256_rsa_pss;
+//! use tdx_workload_attestation::verification::x509::{load_x509_der, get_x509_pubkey};
 //!
 //! // Load signing cert
 //! let cert = load_x509_der("/path/to/cert.der")?;
-//! let signing_key = verification::x509::get_x509_pubkey(&cert)?;
+//! let signing_key = get_x509_pubkey(&cert)?;
 //!
-//! // Verify the digital `signature` on `data` with the `public_key` found in the cert
-//! match verify_signature_sha256_rsa_pss(data, &signature, &public_key) {
+//! // Get data and signature
+//!
+//! // Verify the digital `signature` on `data` with the `signing_key` found in the cert
+//! match verify_signature_sha256_rsa_pss(&data, &signature, &signing_key) {
 //!     Ok(true) => println!("Signature is valid."),
-//!     Err(e) => eprintln!("Signature verification failed: {}", e),
+//!     Ok(false) => println!("Signature is not valid."),
+//!     Err(e) => println!("Signature verification failed: {e}"),
 //! }
 //! ```
 

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -8,8 +8,8 @@
 //!
 //! ## Example Usage
 //!
-//! ```rust
-//! use x509::{load_x509_der, get_x509_pubkey, verify_x509_cert};
+//! ```no_run
+//! use tdx_workload_attestation::verification::x509::{load_x509_der, get_x509_pubkey, verify_x509_cert};
 //!
 //! // Load DER formatted certificate from file
 //! let cert = load_x509_der("path/to/certificate.der").expect("Failed to load certificate");
@@ -22,7 +22,8 @@
 //! let issuer_cert = load_x509_der("path/to/isser_certificate.der").expect("Failed to load issuer certificate");
 //! match verify_x509_cert(&cert, &issuer_cert) {
 //!     Ok(true) => println!("Certificate is valid."),
-//!     Err(e) => eprintln!("Certificate verification failed: {}", e),
+//!     Ok(false) => println!("Certificate is not valid."),
+//!     Err(e) => println!("Certificate verification failed: {e}"),
 //! }
 //! ```
 


### PR DESCRIPTION
Several of the doc tests were failing to compile and/or run. This PR makes the needed fixes. Tests that only succeed on TDX platforms are set to `no_run` to avoid panics.

Tested with `cargo test --all-features`