### PR TITLE
Check X509 certificate validity period during cert verification

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,12 @@ pub enum Error {
     #[error("Not supported: {0}")]
     NotSupported(String),
 
+    /// Represents an OpenSSL error.
+    ///
+    /// This variant wraps a `openssl::error::ErrorStack` and provides additional context.
+    #[error("OpenSSL error: {0}")]
+    OpenSslError(#[from] openssl::error::ErrorStack),
+
     /// Represents an error that occurs during parsing of serialized data.
     ///
     /// This variant includes a string describing the parsing error.

--- a/src/verification/signature.rs
+++ b/src/verification/signature.rs
@@ -29,9 +29,7 @@ use crate::error::{Error, Result};
 
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Public};
-#[cfg(feature = "host-gcp-tdx")]
 use openssl::rsa::Padding;
-#[cfg(feature = "host-gcp-tdx")]
 use openssl::sign::RsaPssSaltlen;
 use openssl::sign::Verifier;
 
@@ -48,7 +46,6 @@ use openssl::sign::Verifier;
 /// This function is only available when the `host-gcp-tdx` feature is enabled
 /// because Google Cloud Platform uses a SHA256 with RSA PSS padding signature
 /// scheme, so this is needed to verify GCP-signed data.
-#[cfg(feature = "host-gcp-tdx")]
 pub fn verify_signature_sha256_rsa_pss(
     data: &[u8],
     signature: &[u8],

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -157,6 +157,8 @@ mod tests {
     struct TestCerts {
         root: X509,
         interm: X509,
+	invalid: X509,
+	expired: X509,
     }
 
     fn make_cert(pubkey: &PKeyRef<Public>, sign_key: &PKeyRef<Private>) -> X509 {
@@ -171,8 +173,62 @@ mod tests {
             .unwrap();
         let x509_name = x509_name.build();
 
-        let now = Asn1Time::days_from_now(-1).unwrap();
+        let now = Asn1Time::days_from_now(0).unwrap();
         let end = Asn1Time::days_from_now(5).unwrap();
+
+        let mut cert = openssl::x509::X509::builder().unwrap();
+        cert.set_subject_name(&x509_name).unwrap();
+        cert.set_issuer_name(&x509_name).unwrap();
+        cert.set_not_before(&now).unwrap();
+        cert.set_not_after(&end).unwrap();
+
+        cert.set_pubkey(pubkey).unwrap();
+        cert.sign(sign_key, MessageDigest::sha256()).unwrap();
+
+        cert.build()
+    }
+
+    fn make_invalid_cert(pubkey: &PKeyRef<Public>, sign_key: &PKeyRef<Private>) -> X509 {
+        let mut x509_name = openssl::x509::X509NameBuilder::new().unwrap();
+        x509_name.append_entry_by_text("C", "US").unwrap();
+        x509_name.append_entry_by_text("ST", "CA").unwrap();
+        x509_name
+            .append_entry_by_text("O", "Some organization")
+            .unwrap();
+        x509_name
+            .append_entry_by_text("CN", "www.example.com")
+            .unwrap();
+        let x509_name = x509_name.build();
+
+        let now = Asn1Time::days_from_now(5).unwrap();
+        let end = Asn1Time::days_from_now(7).unwrap();
+
+        let mut cert = openssl::x509::X509::builder().unwrap();
+        cert.set_subject_name(&x509_name).unwrap();
+        cert.set_issuer_name(&x509_name).unwrap();
+        cert.set_not_before(&now).unwrap();
+        cert.set_not_after(&end).unwrap();
+
+        cert.set_pubkey(pubkey).unwrap();
+        cert.sign(sign_key, MessageDigest::sha256()).unwrap();
+
+        cert.build()
+    }
+
+    fn make_expired_cert(pubkey: &PKeyRef<Public>, sign_key: &PKeyRef<Private>) -> X509 {
+        let mut x509_name = openssl::x509::X509NameBuilder::new().unwrap();
+        x509_name.append_entry_by_text("C", "US").unwrap();
+        x509_name.append_entry_by_text("ST", "CA").unwrap();
+        x509_name
+            .append_entry_by_text("O", "Some organization")
+            .unwrap();
+        x509_name
+            .append_entry_by_text("CN", "www.example.com")
+            .unwrap();
+        let x509_name = x509_name.build();
+
+        let now = Asn1Time::from_str("20241231235900.0").unwrap();
+        let end = Asn1Time::from_str("20251231235900.0").unwrap();
 
         let mut cert = openssl::x509::X509::builder().unwrap();
         cert.set_subject_name(&x509_name).unwrap();
@@ -202,6 +258,8 @@ mod tests {
         TestCerts {
             root: make_cert(pubkey, privkey),
             interm: make_cert(pubkey2, privkey),
+	    invalid: make_invalid_cert(pubkey2, privkey),
+	    expired: make_expired_cert(pubkey2, privkey),
         }
     }
 
@@ -234,16 +292,21 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_x509_cert_expired() -> Result<()> {
-        let test_certs = setup();
-
-	let t1 = Asn1Time::days_from_now(-5).unwrap();
-        let t2 = Asn1Time::days_from_now(-2).unwrap();
-	test_certs.interm.set_not_before(&now).unwrap();
-        test_certs.interm.set_not_after(&end).unwrap();
+    fn test_verify_x509_cert_invalid() -> Result<()> {
+        let mut test_certs = setup();
         assert!(
-            !verify_x509_cert(&test_certs.interm, &test_certs.root)
+            !verify_x509_cert(&test_certs.invalid, &test_certs.root)
                 .expect("certificate signature should not be valid")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_x509_cert_expired() -> Result<()> {
+        let mut test_certs = setup();
+        assert!(
+            !verify_x509_cert(&test_certs.expired, &test_certs.root)
+                .expect("certificate signature should be expired")
         );
         Ok(())
     }

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -134,9 +134,7 @@ pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
     }
 
     if !in_validity_period {
-	return Err(Error::VerificationError(
-            "Cert not in validity period".to_string(),
-        ));
+	return Ok(false);
     }
 
     // Then, check the signature
@@ -227,8 +225,8 @@ mod tests {
             .unwrap();
         let x509_name = x509_name.build();
 
-        let now = Asn1Time::from_str("20241231235900.0").unwrap();
-        let end = Asn1Time::from_str("20251231235900.0").unwrap();
+        let now = Asn1Time::from_str("20241231235900Z").unwrap();
+        let end = Asn1Time::from_str("20251231235900Z").unwrap();
 
         let mut cert = openssl::x509::X509::builder().unwrap();
         cert.set_subject_name(&x509_name).unwrap();
@@ -293,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_verify_x509_cert_invalid() -> Result<()> {
-        let mut test_certs = setup();
+        let test_certs = setup();
         assert!(
             !verify_x509_cert(&test_certs.invalid, &test_certs.root)
                 .expect("certificate signature should not be valid")
@@ -303,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_verify_x509_cert_expired() -> Result<()> {
-        let mut test_certs = setup();
+        let test_certs = setup();
         assert!(
             !verify_x509_cert(&test_certs.expired, &test_certs.root)
                 .expect("certificate signature should be expired")

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use crate::error::{Error, Result};
+use openssl::asn1::Asn1Time;
 use openssl::pkey::{PKey, Public};
 use openssl::x509::{X509, X509VerifyResult};
 use std::fs::File;
@@ -90,16 +91,18 @@ pub fn load_x509_der(cert_path: &str) -> Result<X509> {
     x509_from_der_bytes(&cert_bytes)
 }
 
-/// Verifies an X.509 certificate's signature.
+/// Verifies an X.509 certificate's signature and expiry.
 ///
-/// This function performs two checks to verify the validity of the certificate:
+/// This function performs three checks to verify the validity of the
+/// certificate:
 /// 1. It checks whether the provided `issuer_cert` is the issuer of the `cert`.
-/// 2. It verifies the signature of the `cert` using the public key from the
+/// 2. It checks that the `cert` is within the validity period and has not expired.
+/// 3. It verifies the signature of the `cert` using the public key from the
 ///    `issuer_cert`.
 ///
 /// # Errors
 ///
-/// - `Error::VerificationError` if the issuer verification fails.
+/// - `Error::VerificationError` if the issuer or validity verification fails.
 /// - `Error::SignatureError` if the signature verification fails.
 pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
     // First, check the issuer
@@ -111,6 +114,30 @@ pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
             ));
         }
     };
+
+    // Second, check the certificate's validity period
+    let mut in_validity_period = false;
+    let now = Asn1Time::days_from_now(0)
+	.map_err(|e| Error::OpenSslError(e))?;
+    let time_since_valid = now.compare(cert.not_before())
+	.map_err(|e| Error::OpenSslError(e))?;
+
+    if time_since_valid.is_ge() {
+	// only keep checking if the current time is later than the cert's not_before
+	let time_to_expiration = now.compare(cert.not_after())
+	    .map_err(|e| Error::OpenSslError(e))?;
+
+	if time_to_expiration.is_lt() {
+	    // if we get here, we are within the validity period of the cert
+	    in_validity_period = true;
+	}
+    }
+
+    if !in_validity_period {
+	return Err(Error::VerificationError(
+            "Cert not in validity period".to_string(),
+        ));
+    }
 
     // Then, check the signature
     let issuer_pkey = get_x509_pubkey(issuer_cert)?;
@@ -144,7 +171,7 @@ mod tests {
             .unwrap();
         let x509_name = x509_name.build();
 
-        let now = Asn1Time::days_from_now(0).unwrap();
+        let now = Asn1Time::days_from_now(-1).unwrap();
         let end = Asn1Time::days_from_now(5).unwrap();
 
         let mut cert = openssl::x509::X509::builder().unwrap();
@@ -202,6 +229,21 @@ mod tests {
         assert!(
             verify_x509_cert(&test_certs.interm, &test_certs.root)
                 .expect("certificate signature should be valid")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_x509_cert_expired() -> Result<()> {
+        let test_certs = setup();
+
+	let t1 = Asn1Time::days_from_now(-5).unwrap();
+        let t2 = Asn1Time::days_from_now(-2).unwrap();
+	test_certs.interm.set_not_before(&now).unwrap();
+        test_certs.interm.set_not_after(&end).unwrap();
+        assert!(
+            !verify_x509_cert(&test_certs.interm, &test_certs.root)
+                .expect("certificate signature should not be valid")
         );
         Ok(())
     }

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -117,24 +117,25 @@ pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
 
     // Second, check the certificate's validity period
     let mut in_validity_period = false;
-    let now = Asn1Time::days_from_now(0)
-	.map_err(|e| Error::OpenSslError(e))?;
-    let time_since_valid = now.compare(cert.not_before())
-	.map_err(|e| Error::OpenSslError(e))?;
+    let now = Asn1Time::days_from_now(0).map_err(|e| Error::OpenSslError(e))?;
+    let time_since_valid = now
+        .compare(cert.not_before())
+        .map_err(|e| Error::OpenSslError(e))?;
 
     if time_since_valid.is_ge() {
-	// only keep checking if the current time is later than the cert's not_before
-	let time_to_expiration = now.compare(cert.not_after())
-	    .map_err(|e| Error::OpenSslError(e))?;
+        // only keep checking if the current time is later than the cert's not_before
+        let time_to_expiration = now
+            .compare(cert.not_after())
+            .map_err(|e| Error::OpenSslError(e))?;
 
-	if time_to_expiration.is_lt() {
-	    // if we get here, we are within the validity period of the cert
-	    in_validity_period = true;
-	}
+        if time_to_expiration.is_lt() {
+            // if we get here, we are within the validity period of the cert
+            in_validity_period = true;
+        }
     }
 
     if !in_validity_period {
-	return Ok(false);
+        return Ok(false);
     }
 
     // Then, check the signature
@@ -155,8 +156,8 @@ mod tests {
     struct TestCerts {
         root: X509,
         interm: X509,
-	invalid: X509,
-	expired: X509,
+        invalid: X509,
+        expired: X509,
     }
 
     fn make_cert(pubkey: &PKeyRef<Public>, sign_key: &PKeyRef<Private>) -> X509 {
@@ -256,8 +257,8 @@ mod tests {
         TestCerts {
             root: make_cert(pubkey, privkey),
             interm: make_cert(pubkey2, privkey),
-	    invalid: make_invalid_cert(pubkey2, privkey),
-	    expired: make_expired_cert(pubkey2, privkey),
+            invalid: make_invalid_cert(pubkey2, privkey),
+            expired: make_expired_cert(pubkey2, privkey),
         }
     }
 

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -117,10 +117,16 @@ pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
 
     // Second, check the certificate's validity period
     let now = Asn1Time::days_from_now(0).map_err(Error::OpenSslError)?;
-    if now.compare(cert.not_before()).map_err(Error::OpenSslError)?.is_lt()
-	|| now.compare(cert.not_after()).map_err(Error::OpenSslError)?.is_ge()
+    if now
+        .compare(cert.not_before())
+        .map_err(Error::OpenSslError)?
+        .is_lt()
+        || now
+            .compare(cert.not_after())
+            .map_err(Error::OpenSslError)?
+            .is_ge()
     {
-	return Ok(false);
+        return Ok(false);
     }
 
     // Then, check the signature

--- a/src/verification/x509.rs
+++ b/src/verification/x509.rs
@@ -116,26 +116,11 @@ pub fn verify_x509_cert(cert: &X509, issuer_cert: &X509) -> Result<bool> {
     };
 
     // Second, check the certificate's validity period
-    let mut in_validity_period = false;
-    let now = Asn1Time::days_from_now(0).map_err(|e| Error::OpenSslError(e))?;
-    let time_since_valid = now
-        .compare(cert.not_before())
-        .map_err(|e| Error::OpenSslError(e))?;
-
-    if time_since_valid.is_ge() {
-        // only keep checking if the current time is later than the cert's not_before
-        let time_to_expiration = now
-            .compare(cert.not_after())
-            .map_err(|e| Error::OpenSslError(e))?;
-
-        if time_to_expiration.is_lt() {
-            // if we get here, we are within the validity period of the cert
-            in_validity_period = true;
-        }
-    }
-
-    if !in_validity_period {
-        return Ok(false);
+    let now = Asn1Time::days_from_now(0).map_err(Error::OpenSslError)?;
+    if now.compare(cert.not_before()).map_err(Error::OpenSslError)?.is_lt()
+	|| now.compare(cert.not_after()).map_err(Error::OpenSslError)?.is_ge()
+    {
+	return Ok(false);
     }
 
     // Then, check the signature


### PR DESCRIPTION
This PR adds X509 certificate validity period and expiration checking during certificate verification.

### Test this PR (Linux platform required)
```
sudo apt install pkg-config  # needed by openssl Rust lib
cargo test --features host-verification 
```