### PR TITLE
Check if downloaded GCP golden launch endorsement is malformed

### DIFF
--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -160,6 +160,14 @@ impl TeeHost for GcpTdxHost {
         }
 
         // The endorsed MRTD will be within the golden value's TDX measurements structs
+        if uefi_golden.tdx.is_none()
+            || uefi_golden.tdx.measurements.len() == 0
+            || uefi_golden.tdx.measurements[0].mrtd.len() == 0
+        {
+            return Err(Error::ParseError(
+                "Expected TDX measurement structure missing".to_string(),
+            ));
+        }
         let endorsed_mrtd = uefi_golden.tdx.measurements[0].mrtd.as_slice();
 
         // Finally, we compare the two MRTD values

--- a/src/gcp/mod.rs
+++ b/src/gcp/mod.rs
@@ -161,8 +161,8 @@ impl TeeHost for GcpTdxHost {
 
         // The endorsed MRTD will be within the golden value's TDX measurements structs
         if uefi_golden.tdx.is_none()
-            || uefi_golden.tdx.measurements.len() == 0
-            || uefi_golden.tdx.measurements[0].mrtd.len() == 0
+            || uefi_golden.tdx.measurements.is_empty()
+            || uefi_golden.tdx.measurements[0].mrtd.is_empty()
         {
             return Err(Error::ParseError(
                 "Expected TDX measurement structure missing".to_string(),


### PR DESCRIPTION
This PR adds a format check for the golden launch endorsement downloaded from GCP before parsing the data during MRTD verification on GCP, avoiding a panic on malformed data.