### PR TITLE
Add REPORTDATA binding to AttestationProvider

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -41,6 +41,9 @@ enum Commands {
         /// Save the JSON-encoded TD quote to a file
         #[arg(short, long = "save", default_value = "false")]
         save: bool,
+        /// Hex-encoded data to bind into the TDX REPORTDATA field (max 64 bytes; shorter inputs are zero-padded)
+        #[arg(short = 'r', long = "report-data")]
+        report_data: Option<String>,
     },
 }
 
@@ -55,7 +58,12 @@ fn handle_not_supported(e: Error) -> Result<()> {
     }
 }
 
-fn handle_quote(mrtd_only: bool, out_file: String, save: bool) -> Result<()> {
+fn handle_quote(
+    mrtd_only: bool,
+    out_file: String,
+    save: bool,
+    report_data: Option<String>,
+) -> Result<()> {
     let provider = LinuxTdxProvider::new();
     if mrtd_only {
         match provider.get_launch_measurement() {
@@ -66,7 +74,15 @@ fn handle_quote(mrtd_only: bool, out_file: String, save: bool) -> Result<()> {
             Err(e) => handle_not_supported(e),
         }
     } else {
-        match provider.get_attestation_report() {
+        let result = match report_data {
+            Some(hex_str) => {
+                let bytes = hex::decode(hex_str.trim_start_matches("0x"))
+                    .map_err(|e| Error::ParseError(format!("invalid --report-data hex: {e}")))?;
+                provider.get_attestation_report_with_data(&bytes)
+            }
+            None => provider.get_attestation_report(),
+        };
+        match result {
             Ok(report) => {
                 if save {
                     let mut file = File::create(&out_file)?;
@@ -94,6 +110,7 @@ fn main() -> Result<()> {
             mrtd_only,
             out_file,
             save,
-        } => handle_quote(mrtd_only, out_file, save),
+            report_data,
+        } => handle_quote(mrtd_only, out_file, save, report_data),
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -4,13 +4,65 @@
 //! guests can use to interact with the TEE platform within the guest
 //! environment.
 //!
-//! The trait provides a function for retrieving TEE attestation reports and
+//! The trait provides functions for retrieving TEE attestation reports and
 //! launch-time measurements.
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 pub trait AttestationProvider {
+    /// Retrieves an attestation report for the current TEE environment.
     fn get_attestation_report(&self) -> Result<String>;
+
+    /// Retrieves an attestation report with caller-supplied data bound into
+    /// the TEE's `REPORTDATA` field (or platform-equivalent).
+    ///
+    /// `REPORTDATA` is a TEE-defined field that is signed alongside the rest
+    /// of the report, allowing a verifier to confirm that the report was
+    /// generated in response to a specific challenge (typically a nonce or a
+    /// hash of a transcript). The exact length and padding rules are
+    /// platform-specific; implementations should document and enforce them.
+    ///
+    /// The default implementation returns [`Error::NotSupported`]. Providers
+    /// that can bind data into a report should override this method.
+    fn get_attestation_report_with_data(&self, _report_data: &[u8]) -> Result<String> {
+        Err(Error::NotSupported(
+            "REPORTDATA binding is not supported by this provider".to_string(),
+        ))
+    }
+
     // TODO: Make the return value less dependent on TDX
     fn get_launch_measurement(&self) -> Result<[u8; 48]>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal provider that exercises the default trait methods. It only
+    /// implements the required methods, so `get_attestation_report_with_data`
+    /// should fall through to the trait's default and return `NotSupported`.
+    struct DefaultsProvider;
+
+    impl AttestationProvider for DefaultsProvider {
+        fn get_attestation_report(&self) -> Result<String> {
+            Ok("{}".to_string())
+        }
+
+        fn get_launch_measurement(&self) -> Result<[u8; 48]> {
+            Ok([0; 48])
+        }
+    }
+
+    #[test]
+    fn default_get_attestation_report_with_data_returns_not_supported() {
+        let provider = DefaultsProvider;
+        let err = provider
+            .get_attestation_report_with_data(&[0xDE, 0xAD, 0xBE, 0xEF])
+            .expect_err("default impl must surface NotSupported");
+
+        match err {
+            Error::NotSupported(_) => {}
+            other => panic!("expected NotSupported, got {other:?}"),
+        }
+    }
 }

--- a/src/tdx/mod.rs
+++ b/src/tdx/mod.rs
@@ -56,7 +56,8 @@ impl LinuxTdxProvider {
         Self
     }
 
-    /// Retrieves the `TDREPORT` for the current environment.
+    /// Retrieves the `TDREPORT` for the current environment with empty
+    /// `REPORTDATA`.
     ///
     /// This method internally calls the Linux-specific implementation to fetch
     /// the TD report using the KVM (Kernel-based Virtual Machine) device.
@@ -65,9 +66,33 @@ impl LinuxTdxProvider {
     ///
     /// A `TdReportV15` struct containing the TD report data.
     fn get_tdreport(&self) -> Result<TdReportV15> {
-        let report_data = [0; 64]; // keep report data empty for now
+        self.get_tdreport_with_data(&[])
+    }
 
-        linux::get_tdreport_v15_kvm(&report_data)
+    /// Retrieves the `TDREPORT` for the current environment, binding the
+    /// caller-supplied `report_data` into the TDX `REPORTDATA` field.
+    ///
+    /// `report_data` may be up to [`TDX_REPORT_DATA_LEN`] (64) bytes. Shorter
+    /// inputs are zero-padded on the right to fill the field. Pass an empty
+    /// slice to request a report with an all-zero `REPORTDATA`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if `report_data` is longer than
+    /// [`TDX_REPORT_DATA_LEN`] bytes.
+    fn get_tdreport_with_data(&self, report_data: &[u8]) -> Result<TdReportV15> {
+        if report_data.len() > TDX_REPORT_DATA_LEN {
+            return Err(Error::NotSupported(format!(
+                "report_data length {} exceeds maximum of {} bytes",
+                report_data.len(),
+                TDX_REPORT_DATA_LEN
+            )));
+        }
+
+        let mut buf = [0u8; TDX_REPORT_DATA_LEN];
+        buf[..report_data.len()].copy_from_slice(report_data);
+
+        linux::get_tdreport_v15_kvm(&buf)
     }
 }
 
@@ -95,6 +120,41 @@ impl AttestationProvider for LinuxTdxProvider {
         let report = self.get_tdreport()?;
 
         // Serialize it to a JSON string.
+        let report_str =
+            serde_json::to_string(&report).map_err(|e| Error::SerializationError(e.to_string()))?;
+
+        Ok(report_str)
+    }
+
+    /// Retrieves the attestation report for a TDX Linux guest environment,
+    /// binding `report_data` into the TDX `REPORTDATA` field.
+    ///
+    /// `report_data` may be up to [`TDX_REPORT_DATA_LEN`] (64) bytes; shorter
+    /// inputs are zero-padded on the right.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::NotSupported`] if `report_data` exceeds 64 bytes.
+    /// - [`Error::SerializationError`] if the TD report cannot be serialized
+    ///   into JSON.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use tdx_workload_attestation::tdx::LinuxTdxProvider;
+    /// use tdx_workload_attestation::provider::AttestationProvider;
+    ///
+    /// let provider = LinuxTdxProvider::new();
+    /// // Bind a 32-byte challenge (e.g. SHA-256 of a transcript) into REPORTDATA.
+    /// let nonce = [0xAB; 32];
+    /// let report = provider
+    ///     .get_attestation_report_with_data(&nonce)
+    ///     .expect("Failed to get attestation report");
+    /// println!("Attestation Report: {}", report);
+    /// ```
+    fn get_attestation_report_with_data(&self, report_data: &[u8]) -> Result<String> {
+        let report = self.get_tdreport_with_data(report_data)?;
+
         let report_str =
             serde_json::to_string(&report).map_err(|e| Error::SerializationError(e.to_string()))?;
 
@@ -155,6 +215,75 @@ mod tests {
             Ok(mrtd) => {
                 // Verify it returned a non-empty buffer
                 assert!(!mrtd.is_empty());
+                Ok(())
+            }
+            Err(e) => handle_expected_tdx_error(e),
+        }
+    }
+
+    #[test]
+    fn test_get_attestation_report_with_data_rejects_oversized_input() {
+        let provider = LinuxTdxProvider::new();
+        let oversized = [0u8; TDX_REPORT_DATA_LEN + 1];
+
+        // Length validation runs before the device call, so this branch
+        // returns a deterministic error even on non-TDX hosts.
+        let err = provider
+            .get_attestation_report_with_data(&oversized)
+            .expect_err("expected length validation to reject 65-byte input");
+
+        match err {
+            Error::NotSupported(msg) => {
+                assert!(
+                    msg.contains("exceeds maximum"),
+                    "unexpected NotSupported message: {msg}"
+                );
+            }
+            other => panic!("expected NotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_get_attestation_report_with_data_accepts_short_input() -> Result<()> {
+        let provider = LinuxTdxProvider::new();
+        // A 32-byte challenge (e.g. SHA-256 digest); the impl should
+        // zero-pad up to TDX_REPORT_DATA_LEN before issuing the request.
+        let nonce = [0xAB_u8; 32];
+
+        match provider.get_attestation_report_with_data(&nonce) {
+            Ok(report) => {
+                assert!(!report.is_empty());
+                let _: serde_json::Value = serde_json::from_str(&report)
+                    .map_err(|e| Error::SerializationError(e.to_string()))?;
+                Ok(())
+            }
+            Err(e) => handle_expected_tdx_error(e),
+        }
+    }
+
+    #[test]
+    fn test_get_attestation_report_with_data_accepts_full_length_input() -> Result<()> {
+        let provider = LinuxTdxProvider::new();
+        let full = [0x5A_u8; TDX_REPORT_DATA_LEN];
+
+        match provider.get_attestation_report_with_data(&full) {
+            Ok(report) => {
+                assert!(!report.is_empty());
+                Ok(())
+            }
+            Err(e) => handle_expected_tdx_error(e),
+        }
+    }
+
+    #[test]
+    fn test_get_attestation_report_with_data_accepts_empty_input() -> Result<()> {
+        let provider = LinuxTdxProvider::new();
+
+        // Empty input should behave equivalently to the no-arg method:
+        // an all-zero REPORTDATA buffer is forwarded to the device.
+        match provider.get_attestation_report_with_data(&[]) {
+            Ok(report) => {
+                assert!(!report.is_empty());
                 Ok(())
             }
             Err(e) => handle_expected_tdx_error(e),


### PR DESCRIPTION
Adds `get_attestation_report_with_data` to the `AttestationProvider` trait so callers can bind a challenge (typically a nonce or a hash of a verifier-supplied transcript) into the TEE's REPORTDATA field. The default trait implementation returns `Error::NotSupported`, keeping the change purely additive for any existing downstream implementers.

`LinuxTdxProvider` overrides the new method: it accepts up to `TDX_REPORT_DATA_LEN` (64) bytes, zero-pads shorter inputs on the right, rejects oversized input with `Error::NotSupported`, and then forwards the buffer through the existing `linux::get_tdreport_v15_kvm` device path. The private `get_tdreport` helper is refactored to delegate to a new `get_tdreport_with_data` so all device interaction flows through a single point.

The `tdx-attest quote` CLI gains a `-r/--report-data <hex>` flag (optional `0x` prefix) that routes to the new method when supplied.

Tests cover the new behavior:
  - trait default returns NotSupported
  - oversize (>64 byte) input is rejected
  - short input (32-byte nonce) is accepted and zero-padded
  - full-length (64-byte) input is accepted
  - empty input behaves like the existing no-arg path

On non-TDX hosts the device-touching cases skip via the existing `handle_expected_tdx_error` helper.